### PR TITLE
Update SOCKS Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "request": "^2.67.0",
-    "socks": "^1.1.8"
+    "socks": "^2.1.6"
   },
   "devDependencies": {
     "mocha": "^2.3.4"


### PR DESCRIPTION
warning tor-request > socks@1.1.10: If using 2.x branch, please upgrade to at least 2.1.6 to avoid a serious bug with socket data flow and an import issue introduced in 2.1.0