### PR TITLE
Pipe Streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ tr.request({ url: 'google.com', headers: { 'user-agent': 'giraffe' }}, function 
 ## Request Pipe Streaming
    ```request = require('request')
       request.proxy = 'http://127.0.0.1:9050'
-      request('http://google.com/doodle.png').pipe(fs.createWriteStream('doodle.png'))```
+      request('http://google.com/doodle.png').pipe(fs.createWriteStream('doodle.png'))
+  ```
       
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ basically:
 tr.request({ url: 'google.com', headers: { 'user-agent': 'giraffe' }}, function ( err, response, body ) { /*...*/ })
 ```
 
+## Request Pipe Streaming
+   ```request = require('request')
+      request.proxy = 'http://127.0.0.1:9050'
+      request('http://google.com/doodle.png').pipe(fs.createWriteStream('doodle.png'))```
+      
 ## Test
 
 Tests the original request library by connecting to http://api.ipify.org - returning your ip. Then makes a few additional requests, now through tor-request, and makes sure the ip's are different (went through tor).


### PR DESCRIPTION
Thought this would be cool to add.  Once you have tor running and use this library to renew tor sessions, you can then just call a request using 'proxy' to pipe stream the data fast to your local drive from the url specified.